### PR TITLE
GHC 8.10: implement liftTyped rather than lift; avoid orphan instances

### DIFF
--- a/src/CI/Types.hs
+++ b/src/CI/Types.hs
@@ -62,8 +62,8 @@ $(Aeson.deriveJSON
   Aeson.defaultOptions { Aeson.constructorTagModifier = drop $ T.length "CI_" }
   ''CI)
 
-instance (TH.Lift k, TH.Lift v) => TH.Lift (HashMap k v) where
-  lift hashMap = [|HashMap.fromList $(TH.lift $ HashMap.toList hashMap)|]
+instance (TH.Lift k, TH.Lift v, Eq k, Hashable k) => TH.Lift (HashMap k v) where
+  liftTyped hashMap = [||HashMap.fromList $$(TH.liftTyped $ HashMap.toList hashMap)||]
 
 newtype EnvVarName = EnvVarName { unEnvVarName :: Text }
   deriving (Eq, Hashable, Show, Aeson.FromJSON, Aeson.FromJSONKey, Aeson.ToJSON


### PR DESCRIPTION
Template Haskell Lift instances should implement `liftTyped` rather than `lift`, as we are moving to typed template haskell. This PR does that, and additionally avoids an orphan instance by writing out code explicitly.