### PR TITLE
Include res/vendors.json in sdist

### DIFF
--- a/ci-info.cabal
+++ b/ci-info.cabal
@@ -17,6 +17,7 @@ cabal-version:  >= 1.10
 
 extra-source-files:
     README.md
+    res/vendors.json
 
 source-repository head
   type: git


### PR DESCRIPTION
Recent versions of cabal-install have changed the behavior of source-repository-package so it's a bit stricter. If you don't include this file in the sdist then during the build the TH splice will fail to find the file and compilation will fail. 